### PR TITLE
improve getConsumer

### DIFF
--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -763,7 +763,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
             throw new PulsarClientException("Getting consumer is not supported");
         }
 
-        if ((partition != 0) && (partionedTopicPresent == false)) {
+        if ((partition != 0) && (!partionedTopicPresent)) {
             throw new PulsarClientException("No Partioned topic present");
         }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -721,7 +721,8 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
                         topicConsumers.putIfAbsent(TopicName.get(consumer.getTopic()), consumer);
                         if (consumer.getTopic().contains("-partition-")) {
                             partionedTopicPresent = true;
-                        }});
+                        }
+                });
     }
 
     private void reloadConsumersFromMultiTopicsConsumers() {
@@ -738,7 +739,8 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
                          topicConsumers.putIfAbsent(TopicName.get(c.getTopic()), c);
                          if (c.getTopic().contains("-partition-")) {
                             partionedTopicPresent = true;
-                         }});
+                         }
+                });
     }
 
     // returns null if consumer not found
@@ -761,7 +763,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
             throw new PulsarClientException("Getting consumer is not supported");
         }
 
-        if (partition != 0 && partionedTopicPresent == false) {
+        if ((partition != 0) && (partionedTopicPresent == false)) {
             throw new PulsarClientException("No Partioned topic present");
         }
 

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/instance/ContextImpl.java
@@ -718,7 +718,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
                                 ? ((MultiTopicsConsumerImpl<?>) consumer).getConsumers().stream()
                                 : Stream.of(consumer))
                 .forEach(consumer -> {
-                        topicConsumers.putIfAbsent(TopicName.get(consumer.getTopic()), consumer)
+                        topicConsumers.putIfAbsent(TopicName.get(consumer.getTopic()), consumer);
                         if (consumer.getTopic().contains("-partition-")) {
                             partionedTopicPresent = true;
                         }});
@@ -735,7 +735,7 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
                                 ? ((MultiTopicsConsumerImpl<?>) c).getConsumers().stream()
                                 : Stream.empty() // no changes expected in regular consumers
                 ).forEach(c -> {
-                         topicConsumers.putIfAbsent(TopicName.get(c.getTopic()), c)
+                         topicConsumers.putIfAbsent(TopicName.get(c.getTopic()), c);
                          if (c.getTopic().contains("-partition-")) {
                             partionedTopicPresent = true;
                          }});
@@ -762,7 +762,6 @@ class ContextImpl implements Context, SinkContext, SourceContext, AutoCloseable 
         }
 
         if (partition != 0 && partionedTopicPresent == false) {
-            System.out.println("using condition");
             throw new PulsarClientException("No Partioned topic present");
         }
 

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/instance/ContextImplTest.java
@@ -335,6 +335,7 @@ public class ContextImplTest {
             Assert.fail("Expected exception");
         } catch (PulsarClientException e) {
             // pass
+            Assert.assertTrue(e.getMessage().contains("No Partioned topic present"));
         }
     }
 


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->


### Motivation
In `contextImpl.java` the `getConsumer()` - When trying to get partitioned topic consumer it throws error consumer not found.
Instead show error message that partitioned topic not present.
Also reduces computation to search for consumer.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications
Added a boolean var to check partitioned topic present or not.
when try to get consumer check whether partitioned topic present then proceed.
<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*


This change is already covered by existing tests, such as `ContextImplTest.`



### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
